### PR TITLE
Fixed run-tests input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] - 2025-05-10
+
+### Fixed
+
+- Fixed `run-tests` input not working due to conditions always evaluating to `true`.
+
 ## [2.0.2] - 2025-05-19
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -59,12 +59,12 @@ runs:
       run: ${{ github.action_path }}/build_project.ps1 -referencesVariable ${{ inputs.refs-variable }} -depotDownloaderVersion ${{ inputs.depot-downloader-version }} -config ${{ inputs.configuration }}
 
     - name: Run initial tests
-      if: ${{ inputs.run-tests }}
+      if: ${{ inputs.run-tests == 'true' }}
       shell: pwsh
       run: ${{ github.action_path }}/init_tests.ps1 -referencesVariable ${{ inputs.refs-variable }} -initialRuns ${{ inputs.initial-test-runs }}
 
     - name: Run tests
-      if: ${{ inputs.run-tests }}
+      if: ${{ inputs.run-tests == 'true' }}
       shell: pwsh
       run: dotnet test --no-build --verbosity normal
 


### PR DESCRIPTION
## Description
`run-tests` input isn't working because conditions are always evaluated to `true`.

## Resolution
Updated testing steps conditions to properly evaluate.

## Testing Evidence
Tested on local workflow runs.

## Related PRs/Dependencies
N/A

## Before merging
- [x] If non-cosmetic changes were introduced -> Update project version and changelog.
